### PR TITLE
Feature: Immersive Jump Label Style and Word Jump

### DIFF
--- a/lib/input.coffee
+++ b/lib/input.coffee
@@ -58,6 +58,12 @@ class Input extends HTMLElement
     @setMode('search')
     @editorElement.focus()
 
+  focusWord: ->
+    @focus()
+    @setMode('searchword')
+    @setMode('jump')
+
+
   resetLabelCharChoice: ->
     @labelChar = ''
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,8 +2,9 @@
 _ = require 'underscore-plus'
 {
   getVisibleEditors
-  decorateRanges,
+  decorateRanges
   getLabelChars
+  getRangesForWord
   getRangesForText
 } = require './utils'
 
@@ -27,6 +28,9 @@ module.exports =
     @subscribe atom.commands.add 'atom-text-editor',
       'smalls:start': => @input.focus()
 
+    @subscribe atom.commands.add 'atom-text-editor',
+      'smalls:jump-word': => @input.focusWord()
+
     @subscribe @input.onDidChooseLabel ({labelChar}) =>
       @landOrUpdateLabelCharForLabels(labelChar)
 
@@ -41,6 +45,10 @@ module.exports =
         when 'search'
           @input.resetLabelCharChoice()
           @clearLabels()
+        when 'searchword'
+          @input.resetLabelCharChoice()
+          @clearLabels()
+          @searchWord()
         when 'jump'
           @showLabels()
 
@@ -72,6 +80,13 @@ module.exports =
     return unless text
     for editor in getVisibleEditors()
       markers = decorateRanges(editor, getRangesForText(editor, text))
+      if markers.length
+        @markersByEditor.set(editor, markers)
+
+  searchWord: ->
+    @clearAllMarkers()
+    for editor in getVisibleEditors()
+      markers = decorateRanges(editor, getRangesForWord(editor))
       if markers.length
         @markersByEditor.set(editor, markers)
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,6 +1,8 @@
 {Range} = require 'atom'
 _ = require 'underscore-plus'
 
+smallsWordsPattern = new RegExp (atom.config.get("smalls.jumpWordPattern")), 'g'
+
 getVisibleEditorRange = (editor) ->
   [startRow, endRow] = editor.element.getVisibleRowRange()
   return null unless (startRow? and endRow?)
@@ -10,6 +12,9 @@ getVisibleEditorRange = (editor) ->
 
 getRangesForText = (editor, text) ->
   getRangesForRegExp(editor, ///#{_.escapeRegExp(text)}///ig)
+
+getRangesForWord = (editor) ->
+  getRangesForRegExp(editor, smallsWordsPattern)
 
 getRangesForRegExp = (editor, pattern) ->
   ranges = []
@@ -72,6 +77,7 @@ getLabelChars = ({amount, chars}) ->
 
 module.exports = {
   getRangesForText
+  getRangesForWord
   getRangesForRegExp
   decorateRanges
   ElementBuilder

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Rapid cursor positioning across any visible chars with search and jump.",
   "activationCommands": {
     "atom-workspace": [
-      "smalls:start"
+      "smalls:start",
+      "smalls:jump-word"
     ]
   },
   "keywords": [],
@@ -39,6 +40,12 @@
       "minimum": 0,
       "default": 0,
       "description": "0 means disable. If input exceed this length, automatically start jump mode"
+    },
+    "jumpWordPattern": {
+      "order": 4,
+      "type": "string",
+      "default": "([A-Z]+([0-9a-z])*)|[a-z0-9]{2,}",
+      "description": "Regular expression to label anchors for word boundary jump"
     },
     "flashOnLand": {
       "order": 32,

--- a/styles/main.less
+++ b/styles/main.less
@@ -1,41 +1,28 @@
 @import "ui-variables";
 @import "syntax-variables";
 
-.smalls.round-box {
-  box-sizing: border-box;
-  border-radius: @component-border-radius;
-}
 
 @color-error-lighten: lighten(@background-color-error, 30%);
 
+@smalls-label-color: hsl( hue( @text-color-warning ), 100% - saturation( @base-background-color ), 60% - lightness( @app-background-color ) * 0.2 );
 atom-text-editor, atom-text-editor::shadow {
   .smalls-label {
-    .smalls.round-box;
-    // border: 1px solid contrast(@background-color-info);
-    // color: contrast(@background-color-info);
-    // background-color: @background-color-info;
-    // box-shadow: 0 0 2px contrast(@background-color-info);
-
+    z-index   : 1;
+    color     : @smalls-label-color;
+    margin-top: -1.5rem;
     background-color: @base-background-color;
-    border: 1px solid @syntax-text-color;
-    box-shadow: 0 0 3px @syntax-text-color;
+    position: absolute;
+    vertical-align: bottom;
 
-    padding-left: 0.2em;
-    padding-right: 0.2em;
-    margin-left: -0.1em;
-    margin-top: -1.25em;
-
-    text-align: center;
     &.not-final {
       color: contrast(@color-error-lighten);
       background-color: @color-error-lighten;
     }
     .decided {
-      text-decoration: line-through;
+      color: fadeout(@smalls-label-color, 70%);
     }
   }
   .smalls-candidate .region {
-    .smalls.round-box;
     border: 1px solid fadeout(@syntax-result-marker-color, 70%);
     background-color: @syntax-selection-color;
   }


### PR DESCRIPTION
## Immersive Jump Label Style

As discussed in issue #5, word-based jump generates too many labels. The result is interruptive due to the sudden emerging of numerous colorful labels. This pull request tunes the style to be relatively more immersive as demonstrated below.
### `smalls:start`

![atom-smalls-immersive](https://dl.dropboxusercontent.com/u/1897501/Screencasts/atom-smalls-immersive-style.gif) 
## Word Jump Implementation and Issues
### `smalls:word-jump`

![atom-smalls-word-jump](https://dl.dropboxusercontent.com/u/1897501/Screencasts/atom-smalls-word-jump.gif) 

![word-jump-issues](https://dl.dropboxusercontent.com/u/1897501/Screenshots/atom-smalls-word-jump-issues.png) 

As shown in the above screenshot, two issues need to be dealt with.
1. The search highlight should be removed when jump starts.
2. The labels overlay on top of the search box.

In addition, the code to implement word jump is not optimal; it is likely need to be refined. 
